### PR TITLE
Adição de links para os sites Iconmonstr e Iconfinder aos links de Bibliotecas de Ícones

### DIFF
--- a/LINKS.md
+++ b/LINKS.md
@@ -227,6 +227,7 @@ para a Linguagem R e suas variantes
 ## 🖌 Biblioteca de ícones
 * [Feather Icons](https://feathericons.com/) - Ícones gratuitos e customizáveis
 * [Font Awesome](https://fontawesome.com) - Obtenha ícones vetoriais e logotipos sociais em seu site com o Font Awesome
+* [Iconfinder](https://www.iconfinder.com/) - Site contendo milhões de ícones e ilustrações
 * [Iconfonts](https://icofont.com) - Mais de 2100 ícones gratuitos para incrementar seus designs criativos
 * [Iconmonstr](https://iconmonstr.com/) - Site com 316 coleções de ícones gratuitos
 * [Iconscout](https://iconscout.com/) - Site reúne grande acervo de ícones gratuitos

--- a/LINKS.md
+++ b/LINKS.md
@@ -228,6 +228,7 @@ para a Linguagem R e suas variantes
 * [Feather Icons](https://feathericons.com/) - Ícones gratuitos e customizáveis
 * [Font Awesome](https://fontawesome.com) - Obtenha ícones vetoriais e logotipos sociais em seu site com o Font Awesome
 * [Iconfonts](https://icofont.com) - Mais de 2100 ícones gratuitos para incrementar seus designs criativos
+* [Iconmonstr](https://iconmonstr.com/) - Site com 316 coleções de ícones gratuitos
 * [Iconscout](https://iconscout.com/) - Site reúne grande acervo de ícones gratuitos
 * [LineIcons](https://lineicons.com/icons) - Mais de 2000 ícone no estilo line icons
 * [Streamline](https://app.streamlineicons.com) - Biblioteca repleta de ícones para ser usado


### PR DESCRIPTION
Adição de links para os sites Iconmonstr e Iconfinder aos links de Bibliotecas de Ícones. As alterações foram feitas na branch addNewIconMonstrAndIconFinderLinks, no arquivo LINKS.md